### PR TITLE
Add TTL support (EXPIRE, TTL, EXPIREAT) to Redis extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ duckdb_unittest_tempdir/
 testext
 test/python/__pycache__/
 .Rhistory
+.env
+.opencode/
+AGENTS.md
+vcpkg/
+vcpkg_installed/

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Currently supported Redis operations:
 - Hash operations: `HGET`, `HSET`, `HGETALL`, `HSCAN`, `HSCAN_OVER_SCAN`
 - List operations: `LPUSH`, `LRANGE`, `LRANGE_TABLE`
 - Key operations: `DEL`, `EXISTS`, `TYPE`, `SCAN`, `KEYS`
+- TTL operations: `EXPIRE`, `TTL`, `EXPIREAT`
 - Batch and discovery operations: `SCAN`, `HSCAN_OVER_SCAN`, `KEYS`
 
 ## Quick Reference: Available Functions
@@ -33,6 +34,9 @@ Currently supported Redis operations:
 | `redis_del(key, secret)` | Scalar | Delete a key (returns TRUE if deleted) |
 | `redis_exists(key, secret)` | Scalar | Check if a key exists (returns TRUE if exists) |
 | `redis_type(key, secret)` | Scalar | Get the type of a key |
+| `redis_expire(key, seconds, secret)` | Scalar | Set TTL in seconds (returns TRUE if set) |
+| `redis_ttl(key, secret)` | Scalar | Get remaining TTL (-2=key not exists, -1=no expiry) |
+| `redis_expireat(key, timestamp, secret)` | Scalar | Set expiry at Unix timestamp (returns TRUE if set) |
 | `redis_scan(cursor, pattern, count, secret)` | Scalar | Scan keys (returns cursor:keys_csv) |
 | `redis_hscan(key, cursor, pattern, count, secret)` | Scalar | Scan fields in a hash |
 | `redis_keys(pattern, secret)` | Table | List all keys matching a pattern |
@@ -155,6 +159,22 @@ SELECT redis_exists('user:1', 'redis');
 
 -- Get the type of a key
 SELECT redis_type('user:1', 'redis');
+```
+
+### TTL Operations
+```sql
+-- Set a key to expire in 1 hour
+SELECT redis_expire('session:123', 3600, 'redis');
+
+-- Check remaining TTL
+SELECT redis_ttl('session:123', 'redis') as remaining_seconds;
+
+-- Set expiry at specific timestamp
+SELECT redis_expireat('cache:item', 1736918400, 'redis');
+
+-- Expire all session keys in a query
+UPDATE sessions
+SET expired = CASE WHEN redis_expire('session:' || id, 300, 'redis') THEN TRUE ELSE FALSE END;
 ```
 
 ### Batch and Discovery Operations

--- a/test/sql/redis.test
+++ b/test/sql/redis.test
@@ -87,6 +87,21 @@ SELECT * FROM redis_hscan_over_scan('*', '*', 100, 'nonexistent_secret');
 ----
 Redis secret not found
 
+statement error
+SELECT redis_expire('mykey', 3600, 'nonexistent_secret');
+----
+Redis secret not found
+
+statement error
+SELECT redis_ttl('mykey', 'nonexistent_secret');
+----
+Redis secret not found
+
+statement error
+SELECT redis_expireat('mykey', 1736918400, 'nonexistent_secret');
+----
+Redis secret not found
+
 # Test that we can create a redis secret
 statement ok
 CREATE SECRET my_test_secret (


### PR DESCRIPTION
Adds three scalar functions for managing key time-to-live in Redis:
- redis_expire(key, seconds, secret): Set TTL in seconds, returns TRUE if set
- redis_ttl(key, secret): Get remaining TTL (-2=key not exist, -1=no expiry)
- redis_expireat(key, timestamp, secret): Set expiry at Unix timestamp, returns TRUE

Implementation details:
- Added 4 protocol formatters to RedisProtocol class
- Added parseIntegerResponse() helper for parsing integer responses
- Updated extension version from 2025120401 to 2026011401
- Added error-handling tests for non-existent secrets
- Updated documentation with features, reference table, and usage examples

All functions follow existing patterns and pass unit tests. Live-tested against local Redis instance - all TTL operations working correctly.